### PR TITLE
Fixed MinecraftClientMixin to assign it to NO_JOBS later

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ fabric_kotlin_version=1.10.19+kotlin.1.9.23
 yarn_mappings=1.20+build.1
 minecraft_version=1.20
 
-mod_version=0.0.1
+mod_version=0.0.2

--- a/src/main/java/net/mymai1208/villageroverlay/mixin/impl/MinecraftClientMixin.java
+++ b/src/main/java/net/mymai1208/villageroverlay/mixin/impl/MinecraftClientMixin.java
@@ -12,6 +12,7 @@ import net.mymai1208.villageroverlay.VillagerOverlay;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -26,10 +27,15 @@ public abstract class MinecraftClientMixin {
     @Shadow @Nullable public ClientPlayerEntity player;
 
     @Shadow @Nullable public HitResult crosshairTarget;
-    private static final List<VillagerProfession> NO_JOBS = Arrays.asList(VillagerProfession.NONE, VillagerProfession.NITWIT);
+
+    @Unique
+    private static List<VillagerProfession> NO_JOBS = null;
 
     @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;tick()V"))
-    public void tick(CallbackInfo ci) {
+    public void villager_overlay$tick(CallbackInfo ci) {
+        if (NO_JOBS == null)
+            NO_JOBS = Arrays.asList(VillagerProfession.NONE, VillagerProfession.NITWIT);
+
         if(crosshairTarget != null) {
             if (crosshairTarget.getType() != HitResult.Type.ENTITY) {
                 return;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
     "villager_overlay.mixins.json"
   ],
   "depends": {
-    "fabric-language-kotlin": "${fabric_kotlin_version}",
+    "fabric-language-kotlin": ">=${fabric_kotlin_version}",
     "fabricloader": ">=${fabric_loader_version}",
     "minecraft": ">=1.20",
     "java": ">=17"


### PR DESCRIPTION
Patchouli との競合を確認、直接的な関係はなかった。
→ Patchouli もMinecraftClient (yarn mappings) をMixinしており、何かしらのタイミングがずれたと考えられる

NO_JOBS へ先に代入せずにMinecraftClient.tick()でnullのときに代入するように変更

